### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,29 @@
 repos:
 
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+- repo: https://github.com/pycqa/isort
+  rev: 5.6.4
   hooks:
     - id: isort
-      exclude: '^.*migrations.*$'
 
 - repo: https://github.com/ambv/black
-  rev: 19.10b0
+  rev: 20.8b1
   hooks:
     - id: black
       args: [--line-length=100, --safe]
-      exclude: '^.*migrations.*$'
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.4
+  hooks:
+  - id: flake8
+    additional_dependencies:
+    - flake8-blind-except
+    - flake8-comprehensions
+    - flake8-pep3101
+    - flake8-debugger
 
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.4.0
+  rev: v3.4.0
   hooks:
     - id: trailing-whitespace
     - id: check-merge-conflict
     - id: debug-statements
-    - id: flake8
-      exclude: '^.*migrations.*$'
-      additional_dependencies: [
-        'flake8-blind-except',
-        'flake8-comprehensions',
-        'flake8-pep3101',
-        'flake8-debugger'
-      ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,5 @@
 [tool.isort]
-combine_as_imports = true
-default_section = "FIRSTPARTY"
-line_length = 100
-multi_line_output = 3
-force_grid_wrap = 0
-include_trailing_comma = true
-not_skip = "__init__.py"
-skip = "migrations"
-known_third_party = ["django"]
-known_first_party = [
-    "django_cloudtask",
-]
+profile = "black"
 
 [tool.black]
 line-length = 120

--- a/src/django_cloudtask/management/commands/sync_scheduler.py
+++ b/src/django_cloudtask/management/commands/sync_scheduler.py
@@ -58,7 +58,8 @@ class Command(BaseCommand):
                         client.resume_job(name)
 
                     client.update_job(
-                        job, field_mask(None, job),
+                        job,
+                        field_mask(None, job),
                     )
 
                     if existing_config[name][2] == JobEnum.State.PAUSED:
@@ -67,7 +68,9 @@ class Command(BaseCommand):
             else:
                 # new task was created
                 log.info(
-                    "sync_scheduler.create", task_id=task_id, schedule=schedule,
+                    "sync_scheduler.create",
+                    task_id=task_id,
+                    schedule=schedule,
                 )
                 client.create_job(
                     parent,

--- a/tests/test_django_cloudtask.py
+++ b/tests/test_django_cloudtask.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
+
 from django_cloudtask import __version__
 
 


### PR DESCRIPTION
* Use official hooks for isort and flake8, rather than old mirrors in pre-commit org
* Upgrade to latest versions of everything
* Use new isort 'black' profile rather than hand configuration
* Drop exclusion of 'migrations' since they don't exist, and anyway why not have nicely formatted migrations?